### PR TITLE
Add track balloon button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -236,6 +236,13 @@ const App = () => {
                 centerLongitude={data.longitude[index]}
                 centerLatitude={data.latitude[index]}
                 shareMap={setMap}
+                trackBalloon={() => {
+                    setIndex(data.time.length - 1)
+                    map.setCenter([
+                        data.longitude.slice(-1).pop(), 
+                        data.latitude.slice(-1).pop()
+                    ])
+                }}
             />
 
             <MapTrace

--- a/src/Map.js
+++ b/src/Map.js
@@ -7,6 +7,7 @@ import { IconButton, Typography } from '@material-ui/core'
 import MyLocationIcon from '@material-ui/icons/MyLocation'
 import AddIcon from '@material-ui/icons/Add'
 import RemoveIcon from '@material-ui/icons/Remove'
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward'
 import Box from '@material-ui/core/Box'
 import Link from '@material-ui/core/Link'
 import Tooltip from '@material-ui/core/Tooltip'
@@ -21,6 +22,7 @@ const Map = ({
     centerLongitude,
     centerLatitude,
     shareMap,
+    trackBalloon,
 }) => {
 
     const [zoom, setZoom] = useState(6)
@@ -113,6 +115,11 @@ const Map = ({
                     <Tooltip title="Zoom Out" placement="left">
                         <IconButton onClick={zoomOut}>
                             <RemoveIcon />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Track Balloon" placement="left">
+                        <IconButton onClick={trackBalloon}>
+                            <ArrowForwardIcon />
                         </IconButton>
                     </Tooltip>
                     <Tooltip title="Locate Me" placement="left">


### PR DESCRIPTION
This pull request adds a button to track the balloon, i.e. jump the point index to the highest value. 

![image](https://user-images.githubusercontent.com/53421382/124364473-18629c00-dc42-11eb-9531-170decb856ac.png)

Clicking the button makes the projection appear and the map gets centered on the balloon.

![image](https://user-images.githubusercontent.com/53421382/124364498-35976a80-dc42-11eb-845c-b1995ba1d05a.png)
